### PR TITLE
feat: Added MiniPlaceholders integration

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,6 +20,7 @@ dependencies {
     implementation("cloud.commandframework:cloud-velocity:1.8.2")
     implementation("cloud.commandframework:cloud-minecraft-extras:1.8.2")
     compileOnly("net.luckperms:api:5.4")
+    compileOnly("io.github.miniplaceholders:miniplaceholders-api:2.0.0")
 }
 
 fun runCommand(command: String): String {

--- a/src/main/java/com/oskarsmc/message/Message.java
+++ b/src/main/java/com/oskarsmc/message/Message.java
@@ -73,6 +73,15 @@ public final class Message {
                 }
             }
 
+            if (messageSettings.miniPlaceholdersIntegration()) {
+                if (DependencyChecker.miniplaceholders()) {
+                    logger.info("MiniPlaceholders integration enabled.");
+                } else {
+                    logger.warn("MiniPlaceholders integration was enabled but MiniPlaceholders was not detected on the proxy. Continuing without it.");
+                    messageSettings.miniPlaceholdersIntegration(false);
+                }
+            }
+
             // Register custom exception handlers
             injector.getInstance(CommandExceptionHandler.class);
 

--- a/src/main/java/com/oskarsmc/message/configuration/MessageSettings.java
+++ b/src/main/java/com/oskarsmc/message/configuration/MessageSettings.java
@@ -37,6 +37,7 @@ public final class MessageSettings {
     private List<String> socialSpyAlias;
 
     private boolean luckpermsIntegration;
+    private boolean miniPlaceholdersIntegration;
     private boolean selfMessageSending;
 
     private final double configVersion;
@@ -72,6 +73,7 @@ public final class MessageSettings {
         // Plugin Features
         this.luckpermsIntegration = toml.getBoolean("plugin.luckperms-integration");
         this.selfMessageSending = toml.getBoolean("plugin.allow-self-message-sending");
+        this.miniPlaceholdersIntegration = toml.getBoolean("plugin.miniplaceholders-integration");
 
         // Messages - Message
         this.messageSentMiniMessage = toml.getString("messages.message-sent");
@@ -194,6 +196,25 @@ public final class MessageSettings {
      */
     public void luckpermsIntegration(boolean luckpermsIntegration) {
         this.luckpermsIntegration = luckpermsIntegration;
+    }
+
+    /**
+     * Get miniplaceholders integration.
+     *
+     * @return MiniPlaceholders integration.
+     */
+    @Pure
+    public boolean miniPlaceholdersIntegration() {
+        return this.miniPlaceholdersIntegration;
+    }
+
+    /**
+     * Set miniplaceholders integration.
+     *
+     * @param miniPlaceholdersIntegration MiniPlaceholders integration
+     */
+    public void miniPlaceholdersIntegration(boolean miniPlaceholdersIntegration) {
+        this.miniPlaceholdersIntegration = miniPlaceholdersIntegration;
     }
 
     /**

--- a/src/main/java/com/oskarsmc/message/logic/MessageHandler.java
+++ b/src/main/java/com/oskarsmc/message/logic/MessageHandler.java
@@ -5,6 +5,7 @@ import com.oskarsmc.message.event.MessageEvent;
 import com.oskarsmc.message.event.StringResult;
 import com.velocitypowered.api.command.CommandSource;
 import com.velocitypowered.api.proxy.Player;
+import io.github.miniplaceholders.api.MiniPlaceholders;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.minimessage.MiniMessage;
@@ -96,6 +97,10 @@ public final class MessageHandler {
                     .resolver(craftLuckpermsPlaceholders("receiver", recipientMetaData));
         } else {
             builder.resolver(craftPlaceholders());
+        }
+
+        if (messageSettings.miniPlaceholdersIntegration()) {
+            builder.resolver(MiniPlaceholders.getRelationalGlobalPlaceholders(event.sender(), event.recipient()));
         }
 
         TagResolver placeholders = builder.resolver(event.extraPlaceholders()).build();

--- a/src/main/java/com/oskarsmc/message/logic/MessageHandler.java
+++ b/src/main/java/com/oskarsmc/message/logic/MessageHandler.java
@@ -2,7 +2,6 @@ package com.oskarsmc.message.logic;
 
 import com.oskarsmc.message.configuration.MessageSettings;
 import com.oskarsmc.message.event.MessageEvent;
-import com.oskarsmc.message.event.StringResult;
 import com.velocitypowered.api.command.CommandSource;
 import com.velocitypowered.api.proxy.Player;
 import io.github.miniplaceholders.api.MiniPlaceholders;
@@ -19,11 +18,7 @@ import net.luckperms.api.platform.PlayerAdapter;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.UnmodifiableView;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
+import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
@@ -53,8 +48,6 @@ public final class MessageHandler {
      * @param event The Message Event instance.
      */
     public void handleMessageEvent(@NotNull MessageEvent event) {
-        event.setResult(StringResult.denied());
-
         if (!messageSettings.selfMessageSending() && event.sender() == event.recipient()) {
             event.sender().sendMessage(Component.translatable("oskarsmc.message.command.common.self-sending-error", NamedTextColor.RED));
             return;

--- a/src/main/java/com/oskarsmc/message/util/DependencyChecker.java
+++ b/src/main/java/com/oskarsmc/message/util/DependencyChecker.java
@@ -16,4 +16,17 @@ public final class DependencyChecker {
             return false;
         }
     }
+
+    /**
+     * Check if the miniplaceholders api is present in the classpath.
+     * @return If the miniplaceholders api is present in the classpath.
+     */
+    public static boolean miniplaceholders() {
+        try {
+            Class.forName("io.github.miniplaceholders.api.MiniPlaceholders");
+            return true;
+        } catch (ClassNotFoundException exception) {
+            return false;
+        }
+    }
 }

--- a/src/main/resources/config.toml
+++ b/src/main/resources/config.toml
@@ -2,6 +2,7 @@
 [plugin]
 enabled = true
 luckperms-integration = true # If luckperms is found, use luckperms prefixes and suffixes.
+miniplaceholders-integration = true # If miniplaceholders is present, you can use the MiniPlaceholders placeholders in the messages.
 allow-self-message-sending = true # Allow a player to send messages to themselves.
 
 # Customise messages using MiniMessage

--- a/src/main/resources/velocity-plugin.json
+++ b/src/main/resources/velocity-plugin.json
@@ -8,6 +8,15 @@
     "OskarsMC",
     "OskarZyg"
   ],
-  "dependencies": [],
+  "dependencies": [
+    {
+      "id":"miniplaceholders",
+      "optional":true
+    },
+    {
+      "id":"luckperms",
+      "optional":true
+    }
+  ],
   "main": "com.oskarsmc.message.Message"
 }


### PR DESCRIPTION
With the integration of [MiniPlaceholders](https://github.com/MiniPlaceholders/MiniPlaceholders), it would now be possible to use placeholders from multiple plugins without the need to add exclusive support for each one, in addition, this would allow to use [relational placeholders](https://javadoc.io/doc/io.github.miniplaceholders/miniplaceholders-api/latest/io.github.miniplaceholders.api/io/github/miniplaceholders/api/MiniPlaceholders.html) in messages