### PR TITLE
Add /msgtoggle

### DIFF
--- a/src/main/java/com/oskarsmc/message/Message.java
+++ b/src/main/java/com/oskarsmc/message/Message.java
@@ -8,6 +8,7 @@ import com.google.inject.Injector;
 import com.google.inject.Key;
 import com.google.inject.TypeLiteral;
 import com.oskarsmc.message.command.MessageCommand;
+import com.oskarsmc.message.command.MessageToggleCommand;
 import com.oskarsmc.message.command.ReplyCommand;
 import com.oskarsmc.message.command.SocialSpyCommand;
 import com.oskarsmc.message.configuration.MessageSettings;
@@ -91,6 +92,7 @@ public final class Message {
 
             // Commands
             injector.getInstance(MessageCommand.class);
+            injector.getInstance(MessageToggleCommand.class);
             injector.getInstance(SocialSpyCommand.class);
             injector.getInstance(ReplyCommand.class);
 

--- a/src/main/java/com/oskarsmc/message/Message.java
+++ b/src/main/java/com/oskarsmc/message/Message.java
@@ -12,6 +12,7 @@ import com.oskarsmc.message.command.MessageToggleCommand;
 import com.oskarsmc.message.command.ReplyCommand;
 import com.oskarsmc.message.command.SocialSpyCommand;
 import com.oskarsmc.message.configuration.MessageSettings;
+import com.oskarsmc.message.configuration.UserData;
 import com.oskarsmc.message.locale.CommandExceptionHandler;
 import com.oskarsmc.message.locale.TranslationManager;
 import com.oskarsmc.message.logic.MessageMetrics;
@@ -51,6 +52,7 @@ public final class Message {
     @Subscribe
     public void onProxyInitialization(ProxyInitializeEvent event) {
         MessageSettings messageSettings = new MessageSettings(dataFolder, logger);
+        UserData userData = new UserData(dataFolder, logger);
 
         injector = injector.createChildInjector(
                 new CloudInjectionModule<>(

--- a/src/main/java/com/oskarsmc/message/command/MessageCommand.java
+++ b/src/main/java/com/oskarsmc/message/command/MessageCommand.java
@@ -13,6 +13,7 @@ import com.oskarsmc.message.util.DefaultPermission;
 import com.velocitypowered.api.command.CommandSource;
 import com.velocitypowered.api.proxy.Player;
 import com.velocitypowered.api.proxy.ProxyServer;
+import net.kyori.adventure.text.Component;
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -36,12 +37,15 @@ public final class MessageCommand {
                 .permission(new DefaultPermission("osmc.message.send"))
                 .handler(context -> {
                     Player receiver = context.get("player");
-
-                    proxyServer.getEventManager().fire(new MessageEvent(
-                            context.getSender(),
-                            receiver,
-                            context.get("message")
-                    )).thenAccept(messageHandler::handleMessageEvent);
+                    if (!messageHandler.canBeMessaged.getOrDefault(receiver, true) && !context.getSender().hasPermission("osmc.message.bypass")) {
+                        context.getSender().sendMessage(Component.translatable("oskarsmc.messages.disabled"));
+                    } else {
+                        proxyServer.getEventManager().fire(new MessageEvent(
+                                context.getSender(),
+                                receiver,
+                                context.get("message")
+                        )).thenAccept(messageHandler::handleMessageEvent);
+                    }
                 })
         );
     }

--- a/src/main/java/com/oskarsmc/message/command/MessageCommand.java
+++ b/src/main/java/com/oskarsmc/message/command/MessageCommand.java
@@ -7,6 +7,7 @@ import cloud.commandframework.velocity.VelocityCommandManager;
 import cloud.commandframework.velocity.arguments.PlayerArgument;
 import com.google.inject.Inject;
 import com.oskarsmc.message.configuration.MessageSettings;
+import com.oskarsmc.message.configuration.UserData;
 import com.oskarsmc.message.event.MessageEvent;
 import com.oskarsmc.message.logic.MessageHandler;
 import com.oskarsmc.message.util.DefaultPermission;
@@ -26,9 +27,10 @@ public final class MessageCommand {
      * @param commandManager Command Manager
      * @param proxyServer Proxy Server
      * @param messageHandler Message Handler
+     * @param userData User Data
      */
     @Inject
-    public MessageCommand(@NotNull MessageSettings messageSettings, @NotNull VelocityCommandManager<CommandSource> commandManager, ProxyServer proxyServer, MessageHandler messageHandler) {
+    public MessageCommand(@NotNull MessageSettings messageSettings, @NotNull VelocityCommandManager<CommandSource> commandManager, ProxyServer proxyServer, MessageHandler messageHandler, UserData userData) {
         Command.Builder<CommandSource> builder = commandManager.commandBuilder("message", messageSettings.messageAliases().toArray(new String[0]));
 
         commandManager.command(builder
@@ -37,7 +39,7 @@ public final class MessageCommand {
                 .permission(new DefaultPermission("osmc.message.send"))
                 .handler(context -> {
                     Player receiver = context.get("player");
-                    if (!messageHandler.canBeMessaged.getOrDefault(receiver, true) && !context.getSender().hasPermission("osmc.message.bypass")) {
+                    if (!userData.getUserMessageState(receiver.getUniqueId()) && !context.getSender().hasPermission("osmc.message.bypass")) {
                         context.getSender().sendMessage(Component.translatable("oskarsmc.messages.disabled"));
                     } else {
                         proxyServer.getEventManager().fire(new MessageEvent(

--- a/src/main/java/com/oskarsmc/message/command/MessageToggleCommand.java
+++ b/src/main/java/com/oskarsmc/message/command/MessageToggleCommand.java
@@ -1,0 +1,59 @@
+package com.oskarsmc.message.command;
+
+import cloud.commandframework.Command;
+import cloud.commandframework.velocity.VelocityCommandManager;
+import com.google.inject.Inject;
+import com.oskarsmc.message.configuration.MessageSettings;
+import com.oskarsmc.message.logic.MessageHandler;
+import com.velocitypowered.api.command.CommandSource;
+import com.velocitypowered.api.proxy.Player;
+import net.kyori.adventure.text.Component;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Message Toggle command
+ */
+public final class MessageToggleCommand {
+    @Inject
+    private MessageHandler messageHandler;
+
+    /**
+     * Construct the social spy command.
+     *
+     * @param messageSettings Message Settings
+     * @param commandManager  Command Manager
+     */
+    @Inject
+    public MessageToggleCommand(@NotNull MessageSettings messageSettings, @NotNull VelocityCommandManager<CommandSource> commandManager) {
+        Command.Builder<CommandSource> builder = commandManager.commandBuilder("msgtoggle").permission("osmc.message.toggle");
+
+        commandManager.command(builder
+                .senderType(Player.class)
+                .literal("on")
+                .handler(context -> {
+                    messageHandler.canBeMessaged.put(context.getSender(), true);
+                    context.getSender().sendMessage(Component.translatable("oskarsmc.message.command.msgtoggle.on"));
+                })
+        );
+
+        commandManager.command(builder
+                .senderType(Player.class)
+                .literal("off")
+                .handler(context -> {
+                    messageHandler.canBeMessaged.put(context.getSender(), false);
+                    context.getSender().sendMessage(Component.translatable("oskarsmc.message.command.msgtoggle.off"));
+                })
+        );
+
+        commandManager.command(builder
+                .senderType(Player.class)
+                .handler(context -> {
+                    boolean canBeMessaged = messageHandler.canBeMessaged.getOrDefault(context.getSender(), true);
+                    messageHandler.canBeMessaged.put(context.getSender(), !canBeMessaged);
+                    context.getSender().sendMessage(Component.translatable("oskarsmc.message.command.msgtoggle." + (canBeMessaged ? "off" : "on")));
+
+                })
+        );
+
+    }
+}

--- a/src/main/java/com/oskarsmc/message/configuration/UserData.java
+++ b/src/main/java/com/oskarsmc/message/configuration/UserData.java
@@ -1,0 +1,98 @@
+package com.oskarsmc.message.configuration;
+
+import com.google.inject.Inject;
+import com.velocitypowered.api.plugin.annotation.DataDirectory;
+import ninja.leaping.configurate.ConfigurationNode;
+import ninja.leaping.configurate.yaml.YAMLConfigurationLoader;
+import org.jetbrains.annotations.NotNull;
+import org.slf4j.Logger;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.UUID;
+
+/**
+ * User Data class
+ */
+public final class UserData {
+    private final Path dataFolder;
+    private final Path file;
+
+    /**
+     * Construct userdata.
+     *
+     * @param dataFolder Data Folder
+     * @param logger Logger
+     */
+    @Inject
+    public UserData(@DataDirectory @NotNull Path dataFolder, Logger logger) {
+        this.dataFolder = dataFolder;
+        this.file = this.dataFolder.resolve("userdata.yml");
+
+        createUserDataFile();
+    }
+
+    /**
+     * Save the user message state.
+     *
+     * @param playerUUID Player UUID
+     * @param canBeMessaged Can be messaged
+     */
+    public void saveUserMessageState(UUID playerUUID, boolean canBeMessaged) {
+        final ConfigurationNode yaml = loadConfig();
+        yaml.getNode("users", playerUUID.toString(), "canBeMessaged").setValue(canBeMessaged);
+        saveUserData(yaml);
+    }
+
+    /**
+     * Get the user message state.
+     *
+     * @param playerUUID Player UUID
+     * @return Can be messaged
+     */
+    public boolean getUserMessageState(UUID playerUUID) {
+        final ConfigurationNode yaml = loadConfig();
+        return yaml.getNode("users", playerUUID.toString(), "canBeMessaged").getBoolean(true);
+    }
+
+    private void createUserDataFile() {
+        if (!Files.exists(dataFolder)) {
+            try {
+                Files.createDirectory(dataFolder);
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        if (!Files.exists(file)) {
+            try (InputStream in = MessageSettings.class.getResourceAsStream("/userdata.yml")) {
+                assert in != null;
+                Files.copy(in, file);
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
+    private @NotNull Path userDataFile() {
+        return this.file;
+    }
+
+    private ConfigurationNode loadConfig() {
+        try {
+            return YAMLConfigurationLoader.builder().setPath(this.file).build().load();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private void saveUserData(ConfigurationNode yaml) {
+        try {
+            YAMLConfigurationLoader.builder().setPath(this.file).build().save(yaml);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/main/java/com/oskarsmc/message/logic/MessageHandler.java
+++ b/src/main/java/com/oskarsmc/message/logic/MessageHandler.java
@@ -28,6 +28,7 @@ public final class MessageHandler {
     private final MessageSettings messageSettings;
     private final MiniMessage miniMessage = MiniMessage.miniMessage();
     private final ConcurrentHashMap<Player, Player> conversations = new ConcurrentHashMap<>();
+    public final ConcurrentHashMap<CommandSource, Boolean> canBeMessaged = new ConcurrentHashMap<>();
     /**
      * Conversation Watchers
      */

--- a/src/main/java/com/oskarsmc/message/logic/MessageHandler.java
+++ b/src/main/java/com/oskarsmc/message/logic/MessageHandler.java
@@ -28,7 +28,7 @@ public final class MessageHandler {
     private final MessageSettings messageSettings;
     private final MiniMessage miniMessage = MiniMessage.miniMessage();
     private final ConcurrentHashMap<Player, Player> conversations = new ConcurrentHashMap<>();
-    public final ConcurrentHashMap<CommandSource, Boolean> canBeMessaged = new ConcurrentHashMap<>();
+
     /**
      * Conversation Watchers
      */

--- a/src/main/java/com/oskarsmc/message/util/MessageModule.java
+++ b/src/main/java/com/oskarsmc/message/util/MessageModule.java
@@ -4,6 +4,7 @@ import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
 import com.google.inject.Singleton;
 import com.oskarsmc.message.command.MessageCommand;
+import com.oskarsmc.message.command.MessageToggleCommand;
 import com.oskarsmc.message.command.ReplyCommand;
 import com.oskarsmc.message.command.SocialSpyCommand;
 import com.oskarsmc.message.configuration.MessageSettings;
@@ -31,6 +32,7 @@ public final class MessageModule extends AbstractModule {
     protected void configure() {
         bind(MessageSettings.class).toInstance(messageSettings);
         bind(MessageCommand.class).in(Singleton.class);
+        bind(MessageToggleCommand.class).in(Singleton.class);
         bind(ReplyCommand.class).in(Singleton.class);
         bind(SocialSpyCommand.class).in(Singleton.class);
         bind(MessageMetrics.class).in(Singleton.class);

--- a/src/main/resources/translations.json
+++ b/src/main/resources/translations.json
@@ -22,7 +22,7 @@
         "oskarsmc.message.command.socialspy.on": "SocialSpy habilitado.",
         "oskarsmc.message.command.socialspy.off": "SocialSpy deshabilitado.",
         "oskarsmc.message.command.msgtoggle.on": "Mensajes habilitado.",
-        "oskarsmc.message.command.msgtoggle.off": "Messages deshabilitado.",
+        "oskarsmc.message.command.msgtoggle.off": "Mensajes deshabilitado.",
         "oskarsmc.message.command.common.self-sending-error": "No puedes enviarte mensajes a ti mismo.",
         "oskarsmc.messages.disabled": "Ese jugador tiene los mensajes deshabilitados."
       }

--- a/src/main/resources/translations.json
+++ b/src/main/resources/translations.json
@@ -8,7 +8,10 @@
         "oskarsmc.message.command.common.argument.message-description": "The message to send to the player.",
         "oskarsmc.message.command.socialspy.on": "SocialSpy enabled.",
         "oskarsmc.message.command.socialspy.off": "SocialSpy disabled.",
-        "oskarsmc.message.command.common.self-sending-error": "You cannot send messages to yourself."
+        "oskarsmc.message.command.msgtoggle.on": "Messages enabled.",
+        "oskarsmc.message.command.msgtoggle.off": "Messages disabled.",
+        "oskarsmc.message.command.common.self-sending-error": "You cannot send messages to yourself.",
+        "oskarsmc.messages.disabled": "That player has messages disabled."
       }
     },
     {
@@ -18,7 +21,10 @@
         "oskarsmc.message.command.common.argument.message-description": "El mensaje que se enviara al jugador.",
         "oskarsmc.message.command.socialspy.on": "SocialSpy habilitado.",
         "oskarsmc.message.command.socialspy.off": "SocialSpy deshabilitado.",
-        "oskarsmc.message.command.common.self-sending-error": "No puedes enviarte mensajes a ti mismo."
+        "oskarsmc.message.command.msgtoggle.on": "Mensajes habilitado.",
+        "oskarsmc.message.command.msgtoggle.off": "Messages deshabilitado.",
+        "oskarsmc.message.command.common.self-sending-error": "No puedes enviarte mensajes a ti mismo.",
+        "oskarsmc.messages.disabled": "Ese jugador tiene los mensajes deshabilitados."
       }
     }
   ]

--- a/src/main/resources/velocity-plugin.json
+++ b/src/main/resources/velocity-plugin.json
@@ -6,7 +6,8 @@
   "url": "https://software.oskarsmc.com/plugins/velocity/message/",
   "authors": [
     "OskarsMC",
-    "OskarZyg"
+    "OskarZyg",
+    "SnowzNZ"
   ],
   "dependencies": [
     {


### PR DESCRIPTION
implements  #23

- added command `/msgtoggle [on/off]`
- saves the msgtoggle state in `userdata.yml`
- users with the `osmc.message.bypass` permission can send messages to recipients even if they have messages disabled
- added translations for message toggle messages